### PR TITLE
fix: center layout + fix && ligature bug

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -12,12 +12,19 @@ body {
   margin: 0;
   min-height: 100vh;
   background: #0d1117;
+  display: flex;
+  justify-content: center;
+}
+
+#root {
+  width: 100%;
 }
 
 .app {
-  max-width: 920px;
+  max-width: 860px;
+  width: 100%;
   margin: 0 auto;
-  padding: 2rem 1rem 4rem;
+  padding: 2rem 1.5rem 4rem;
 }
 
 h1 {
@@ -94,6 +101,7 @@ h3 { font-family: 'Fira Code', monospace; color: #3fb950; font-size: 0.9rem; }
 code {
   display: inline-block;
   font-family: 'Fira Code', monospace;
+  font-variant-ligatures: none; /* prevent && → 66 and similar ligature bugs */
   background: #0d1117;
   border: 1px solid #30363d;
   border-radius: 4px;
@@ -101,6 +109,7 @@ code {
   margin-top: 0.3rem;
   color: #3fb950;
   font-size: 0.85rem;
+  word-break: break-all;
 }
 
 .option {


### PR DESCRIPTION
Fixes #11

## Changes
- Center the app layout properly on all screen sizes (flexbox on body + full-width root)
- Add `font-variant-ligatures: none` to code blocks — prevents Fira Code from rendering `&&` as `66`
- Add `word-break: break-all` on code for long commands on mobile